### PR TITLE
Enforcing the quota: hook directly in smgrextend()

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -81,9 +81,8 @@ quota_check_SmgrExtend(SMgrRelation reln, ForkNumber forknum, BlockNumber blockn
 		 * We
 		 */
 		ereport(ERROR,
-			(errcode_for_file_access(),
-			errmsg("could not extend file"),
-			errhint("Check free disk space.")));
+				(errcode(ERRCODE_DISK_FULL),
+				errmsg("user's disk space quota exceeded")));
 	}
 
 	return;


### PR DESCRIPTION
This commit is one of TODOs as heikki referred.
Enforcing the quota by using hook directly in smgrextend().

This pr needs some modification in postgres, here is the diff:
https://github.com/BaiShaoqi/postgres/pull/1

Test is pass based on postgres branch: REL_11_STABLE