### PR TITLE
Limit the amount of disk space that a table can use.

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -38,28 +38,6 @@ init_quota_enforcement(void)
 	}
 }
 
-static Oid
-get_rel_owner(Oid relid)
-{
-	HeapTuple	tp;
-
-	tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
-	if (HeapTupleIsValid(tp))
-	{
-		Form_pg_class reltup = (Form_pg_class) GETSTRUCT(tp);
-		Oid			result;
-
-		result = reltup->relowner;
-		ReleaseSysCache(tp);
-		return result;
-	}
-	else
-	{
-		elog(DEBUG1, "could not find owner for relation %u", relid);
-		return InvalidOid;
-	}
-}
-
 /*
  * Permission check hook function. Throws an error if you try to INSERT
  * (or COPY) into a table, and the quota has been exceeded.
@@ -72,7 +50,6 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 	foreach(l, rangeTable)
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
-		Oid			owner;
 
 		/* see ExecCheckRTEPerms() */
 		if (rte->rtekind != RTE_RELATION)
@@ -85,25 +62,18 @@ quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 		if ((rte->requiredPerms & ACL_INSERT) == 0)
 			continue;
 
-		/*
-		 * Perform the check as the relation's owner, rather than the current
-		 * user.
-		 */
-		owner = get_rel_owner(rte->relid);
-		if (owner == InvalidOid)
-			return true; /* no owner, huh? */
 
-		if (!CheckQuota(owner))
+		if (!CheckQuota(rte->relid))
 		{
 			/*
-			 * The owner is out of quota. Report error.
+			 * The relation is out of quota. Report error.
 			 *
 			 * We
 			 */
 			if (ereport_on_violation)
 				ereport(ERROR,
 						(errcode(ERRCODE_DISK_FULL),
-						 errmsg("user's disk space quota exceeded")));
+						 errmsg("table's disk space quota exceeded")));
 			return false;
 		}
 	}

--- a/expected/test_quotas.out
+++ b/expected/test_quotas.out
@@ -1,15 +1,6 @@
 --
-CREATE USER quotatest_user NOLOGIN;
 CREATE TABLE qt (t text);
-ALTER TABLE qt OWNER TO quotatest_user;
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
--- Wait a little, to make sure the background worker has picked up the new size.
-select pg_sleep(5);
- pg_sleep 
-----------
- 
-(1 row)
-
 -- Display the table size.
 select pg_size_pretty(pg_total_relation_size('qt'));
  pg_size_pretty 
@@ -17,19 +8,8 @@ select pg_size_pretty(pg_total_relation_size('qt'));
  13 MB
 (1 row)
 
--- The "disk space used" as shown in quota_status should match
-SELECT rolname,
-       pg_size_pretty(space_used) as used,
-       pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
-    rolname     | used  | quota 
-----------------+-------+-------
- quotatest_user | 13 MB | 
-(1 row)
-
--- Set a quota for the user.
-INSERT INTO quota.config VALUES ('quotatest_user'::regrole, pg_size_bytes('20 MB'));
+-- Set a quota for the relation.
+INSERT INTO quota.config VALUES ('qt'::regclass, pg_size_bytes('20 MB'));
 -- Wait a little, to give the worker a chance to pick up the new quota.
 select pg_sleep(5);
  pg_sleep 
@@ -37,14 +17,13 @@ select pg_sleep(5);
  
 (1 row)
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
-    rolname     | used  | quota 
-----------------+-------+-------
- quotatest_user | 13 MB | 20 MB
+FROM quota.status;
+ tablename | used  | quota 
+-----------+-------+-------
+ qt        | 13 MB | 20 MB
 (1 row)
 
 -- Now insert enough data that the quota is exceeded.
@@ -56,19 +35,18 @@ select pg_sleep(5);
  
 (1 row)
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
-    rolname     | used  | quota 
-----------------+-------+-------
- quotatest_user | 26 MB | 20 MB
+FROM quota.status;
+ tablename | used  | quota 
+-----------+-------+-------
+ qt        | 26 MB | 20 MB
 (1 row)
 
 -- Try to insert again. This should fail, because the quota is exceeded.
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
-ERROR:  user's disk space quota exceeded
+ERROR:  table's disk space quota exceeded
 -- Free up the space, by truncating the table. Now it should work again.
 TRUNCATE qt;
 -- and again wait a little, so that the worker picks up the new file size
@@ -78,14 +56,13 @@ select pg_sleep(5);
  
 (1 row)
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
-    rolname     |    used    | quota 
-----------------+------------+-------
- quotatest_user | 8192 bytes | 20 MB
+FROM quota.status;
+ tablename |    used    | quota 
+-----------+------------+-------
+ qt        | 8192 bytes | 20 MB
 (1 row)
 
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);

--- a/fs_model.c
+++ b/fs_model.c
@@ -35,176 +35,46 @@ PG_FUNCTION_INFO_V1(get_quota_status);
 
 typedef struct FileSizeEntry FileSizeEntry;
 typedef struct RelSizeEntry RelSizeEntry;
-typedef struct RoleSizeEntry RoleSizeEntry;
-typedef struct RoleSizeEntryKey RoleSizeEntryKey;
+typedef struct RelationSizeEntry RelationSizeEntry;
+typedef struct RelationSizeEntryKey RelationSizeEntryKey;
 
 /*
  * Shared memory structure.
  *
- * In shared memory, we keep a hash table of RoleSizeEntrys. It's keyed by
- * role and database OID, and protected by shared->lock. It holds the
- * current total disk space usage, and quota, for each role and database.
+ * In shared memory, we keep a hash table of RelationSizeEntrys. It's keyed by
+ * relid and database OID, and protected by shared->lock. It holds the
+ * current total disk space usage, and quota, for each relation and database.
  */
-struct RoleSizeEntryKey
+struct RelationSizeEntryKey
 {
-	/* hash key consists of role and database OID */
-	Oid			rolid;
+	/* hash key consists of relation and database OID */
+	Oid			relid;
 	Oid			dbid;
 };
 
-struct RoleSizeEntry
+struct RelationSizeEntry
 {
-	RoleSizeEntryKey key;
+	RelationSizeEntryKey key;
 
 	off_t		totalsize;	/* current total space usage */
-	int64		quota;		/* quota from config table, or -1 for no quota */
+	int64		quota;		/* quota from config table */
 };
 
-static HTAB *role_totals_map;
+static HTAB *relation_totals_map;
 
 typedef struct
 {
-	LWLock	   *lock;		/* protects role_totals_map */
+	LWLock	   *lock;		/* protects relation_totals_map */
 } pg_quota_shared_state;
 
 static pg_quota_shared_state *shared;
 
-/*
- * Local memory structures, in the background worker process.
- *
- * There are two hash tables, to track every relation and the files belonging
- * to them.
- *
- * The first hash table, path_to_fsentry_map, contains one FileSizeEntry for
- * every relation file in the data directory. It holds the current size of each
- * file.
- *
- * The second hash table contains one RelSizeEntry for each relation. It holds
- * the owner of each relation.
- *
- * Each background worker only tracks files belonging to the database the worker
- * is assigned to.
- */
-struct FileSizeEntry
-{
-	char		path[MAXPGPATH]; /* XXX: this is overly large for a hash key */
-
-	off_t		filesize;		/* current size of the file. */
-
-	RelSizeEntry *parent;		/* relation this file belongs to. */
-
-	int			generation;		/* generation stamp, to detect removed files */
-};
-
-static HTAB *path_to_fsentry_map;
-
-struct RelSizeEntry
-{
-	RelFileNode rnode;
-
-	Oid			owner;
-
-	int			numfiles;		/* ref count of FileSizeEntrys for this rel */
-	off_t		totalsize;
-
-	dlist_node	orphan_node;	/* link in orphanRels, if owner == InvalidOid */
-};
-
-static HTAB *relfilenode_to_relentry_map;
-
-/* List of RelSizeEntrys without owner. */
-static dlist_head orphanRels;
-
-/* Memory context to hold the in-memory model. */
-static MemoryContext FsModelContext;
-
-/*
- * Current "generation", used to detect entries for files that have been
- * deleted.
- */
-static int generation;
 
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 static Size pg_quota_memsize(void);
 static void pg_quota_shmem_startup(void);
 
-static bool isRelDataFile(const char *path, RelFileNode *rnode);
-static void RemoveFileSize(FileSizeEntry *fsentry);
-static void UpdateFileSize(RelFileNode *rnode, char *filename, off_t newsize);
-
-/*
- * Does it look like a relation data file?
- *
- * Returns the relfilenode in *rnode, if so.
- *
- * Adapted from pg_rewind's similar function.
- */
-static bool
-isRelDataFile(const char *path, RelFileNode *rnode)
-{
-	int			nmatch;
-	bool		matched;
-
-	/*----
-	 * Relation data files can be in one of the following directories:
-	 *
-	 * global/
-	 *		shared relations
-	 *
-	 * base/<db oid>/
-	 *		regular relations, default tablespace
-	 *
-	 * pg_tblspc/<tblspc oid>/<tblspc version>/
-	 *		within a non-default tablespace (the name of the directory
-	 *		depends on version)
-	 *
-	 * And the relation data files themselves have a filename like:
-	 *
-	 * <oid>.<segment number>
-	 *
-	 * We don't care about the segment number here.
-	 *
-	 *----
-	 */
-	rnode->spcNode = InvalidOid;
-	rnode->dbNode = InvalidOid;
-	rnode->relNode = InvalidOid;
-	matched = false;
-
-	nmatch = sscanf(path, "global/%u", &rnode->relNode);
-	if (nmatch == 1)
-	{
-		rnode->spcNode = GLOBALTABLESPACE_OID;
-		rnode->dbNode = InvalidOid;
-		matched = true;
-	}
-	else
-	{
-		nmatch = sscanf(path, "base/%u/%u",
-						&rnode->dbNode, &rnode->relNode);
-		if (nmatch == 2)
-		{
-			rnode->spcNode = DEFAULTTABLESPACE_OID;
-			matched = true;
-		}
-		else
-		{
-			nmatch = sscanf(path, "pg_tblspc/%u/" TABLESPACE_VERSION_DIRECTORY "/%u/%u",
-							&rnode->spcNode, &rnode->dbNode, &rnode->relNode);
-			if (nmatch == 3)
-				matched = true;
-		}
-	}
-
-	/*
-	 * Note: The sscanf tests above can match files that have extra
-	 * characters at the end. Non-main forks, and non-0 segments in
-	 * particular. We'll count them all as part of the relation.
-	 */
-
-	return matched;
-}
 
 /*
  * Per-worker initialization. Create local hashes.
@@ -212,39 +82,8 @@ isRelDataFile(const char *path, RelFileNode *rnode)
 void
 init_fs_model(void)
 {
-	HASHCTL		hash_ctl;
 	HASH_SEQ_STATUS iter;
-	RoleSizeEntry *rolentry;
-
-	if (FsModelContext)
-		MemoryContextDelete(FsModelContext);
-
-	FsModelContext = AllocSetContextCreate(TopMemoryContext,
-										   "Disk quotas FS model context",
-										   ALLOCSET_DEFAULT_SIZES);
-
-	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = MAXPGPATH;
-	hash_ctl.entrysize = sizeof(FileSizeEntry);
-	hash_ctl.hcxt = FsModelContext;
-
-	path_to_fsentry_map = hash_create("path to FileSizeEntry map",
-									  1024,
-									  &hash_ctl,
-									  HASH_ELEM | HASH_CONTEXT);
-
-	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(RelFileNode);
-	hash_ctl.entrysize = sizeof(RelSizeEntry);
-	hash_ctl.hcxt = FsModelContext;
-
-	relfilenode_to_relentry_map =
-	  hash_create("relfilenode to RelSizeEntry map",
-				  1024,
-				  &hash_ctl,
-				  HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
-
-	memset(&orphanRels, 0, sizeof(orphanRels));
+	RelationSizeEntry *relentry;
 
 	/*
 	 * Remove any old entries for this database from the shared memory hash
@@ -252,15 +91,15 @@ init_fs_model(void)
 	 */
 	LWLockAcquire(shared->lock, LW_EXCLUSIVE);
 
-	hash_seq_init(&iter, role_totals_map);
+	hash_seq_init(&iter, relation_totals_map);
 
-	while ((rolentry = hash_seq_search(&iter)) != NULL)
+	while ((relentry = hash_seq_search(&iter)) != NULL)
 	{
 		/* only reset entries for current db */
-		if (rolentry->key.dbid == MyDatabaseId)
+		if (relentry->key.dbid == MyDatabaseId)
 		{
-			(void) hash_search(role_totals_map,
-							   (void *) rolentry,
+			(void) hash_search(relation_totals_map,
+							   (void *) relentry,
 							   HASH_REMOVE, NULL);
 		}
 	}
@@ -293,7 +132,7 @@ pg_quota_memsize(void)
 
 	size = MAXALIGN(sizeof(pg_quota_shared_state));
 	size = add_size(size, hash_estimate_size(MAX_DB_ROLE_ENTRIES,
-											 sizeof(RoleSizeEntry)));
+											 sizeof(RelationSizeEntry)));
 	return size;
 }
 
@@ -311,10 +150,10 @@ pg_quota_shmem_startup(void)
 
 	/* reset in case this is a restart within the postmaster */
 	shared = NULL;
-	role_totals_map = NULL;
+	relation_totals_map = NULL;
 
 	/*
-	 * The RoleSizeEntry hash table is kept in shared memory, so that backends
+	 * The RelationSizeEntry hash table is kept in shared memory, so that backends
 	 * can do lookups in it.
 	 */
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
@@ -328,9 +167,9 @@ pg_quota_shmem_startup(void)
 	}
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(RoleSizeEntryKey);
-	hash_ctl.entrysize = sizeof(RoleSizeEntry);
-	role_totals_map = ShmemInitHash("role OID to RoleSizeEntry map",
+	hash_ctl.keysize = sizeof(RelationSizeEntryKey);
+	hash_ctl.entrysize = sizeof(RelationSizeEntry);
+	relation_totals_map = ShmemInitHash("relation OID to RelationSizeEntry map",
 									MAX_DB_ROLE_ENTRIES,
 									MAX_DB_ROLE_ENTRIES,
 									&hash_ctl,
@@ -339,368 +178,28 @@ pg_quota_shmem_startup(void)
 	LWLockRelease(AddinShmemInitLock);
 }
 
-static void
-RemoveFileSize(FileSizeEntry *fsentry)
-{
-	RelSizeEntry *relentry = fsentry->parent;
-	int64		filesize = fsentry->filesize;
-	Oid			owner = relentry->owner;
-	bool		found;
-
-	/* Remove the FileSizeEntry. */
-	(void) hash_search(path_to_fsentry_map,
-					   (void *) fsentry->path,
-					   HASH_REMOVE, &found);
-	Assert(found);
-
-	/*
-	 * Update the parent relation. If this was the last file of this relation,
-	 * remove the entry for the relation altogether.
-	 */
-	relentry->totalsize -= filesize;
-	relentry->numfiles--;
-	if (relentry->numfiles == 0)
-	{
-		Assert(relentry->totalsize == 0);
-		if (relentry->owner == InvalidOid)
-			dlist_delete(&relentry->orphan_node);
-		(void) hash_search(relfilenode_to_relentry_map,
-						   (void *) relentry,
-						   HASH_REMOVE, &found);
-		Assert(found);
-	}
-
-	/*
-	 * If we know the owner of this file, update its totals too.
-	 */
-	if (OidIsValid(owner) && filesize != 0)
-	{
-		RoleSizeEntry *rolentry;
-		RoleSizeEntryKey key;
-
-		LWLockAcquire(shared->lock, LW_SHARED);
-
-		key.rolid = owner;
-		key.dbid = MyDatabaseId;
-		rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
-												 (void *) &key,
-												 HASH_FIND, NULL);
-		if (rolentry)
-			rolentry->totalsize -= filesize;
-		else
-		{
-			/* shouldn't happen */
-			elog(DEBUG1, "role total not found, corrupt map?");
-		}
-
-		LWLockRelease(shared->lock);
-	}
-}
 
 /*
- * Update the model with the size of one file.
- */
-static void
-UpdateFileSize(RelFileNode *rnode, char *path, off_t newsize)
-{
-	RelSizeEntry *relentry;
-	FileSizeEntry *fsentry;
-	bool		found;
-	off_t		oldsize;
-
-	/* Find or create entry for this relation */
-	relentry = (RelSizeEntry *) hash_search(relfilenode_to_relentry_map,
-											(void *) rnode,
-											HASH_ENTER, &found);
-	if (!found)
-	{
-		relentry->owner = InvalidOid;
-		dlist_push_head(&orphanRels, &relentry->orphan_node);
-
-		relentry->numfiles = 0;
-		relentry->totalsize = 0;
-	}
-
-	/* Find or create entry for this file */
-	fsentry = (FileSizeEntry *) hash_search(path_to_fsentry_map,
-											(void *) path,
-											HASH_ENTER, &found);
-	if (!found)
-	{
-		fsentry->parent = relentry;
-		relentry->numfiles++;
-		fsentry->filesize = 0;
-	}
-	Assert(relentry->numfiles > 0);
-	Assert(fsentry->parent == relentry);
-
-	/* Update file size */
-	oldsize = fsentry->filesize;
-	fsentry->filesize = newsize;
-
-	/* also touch 'generation', to remember that we saw this file to exist */
-	fsentry->generation = generation;
-
-	/*
-	 * If the file size changed, must also update the totals for the relation
-	 * and the owner.
-	 */
-	if (newsize != oldsize)
-	{
-		relentry->totalsize += (newsize - oldsize);
-
-		if (relentry->owner)
-		{
-			RoleSizeEntry *rolentry;
-			RoleSizeEntryKey key;
-
-			LWLockAcquire(shared->lock, LW_EXCLUSIVE);
-
-			key.rolid = relentry->owner;
-			key.dbid = MyDatabaseId;
-			rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
-													 (void *) &key,
-													 HASH_ENTER, &found);
-			if (!found)
-			{
-				rolentry->totalsize = 0;
-				rolentry->quota = -1;
-			}
-
-			rolentry->totalsize += (newsize - oldsize);
-
-			LWLockRelease(shared->lock);
-		}
-	}
-}
-
-/*
- * helper function for refresh_fs_model(), to scan one directory.
- */
-static void
-RebuildRelSizeMapDir(char *dirpath)
-{
-	DIR		   *dirdesc;
-	struct dirent *dirent;
-	char		path[MAXPGPATH];
-
-	dirdesc = AllocateDir(dirpath);
-
-	while((dirent = ReadDirExtended(dirdesc, dirpath, DEBUG1)) != NULL)
-	{
-		struct stat statbuf;
-		RelFileNode rnode;
-
-		if (strcmp(dirent->d_name, ".") == 0 ||
-			strcmp(dirent->d_name, "..") == 0)
-			continue;
-
-		snprintf(path, MAXPGPATH, "%s/%s", dirpath, dirent->d_name);
-
-		/*
-		 * Only count relation files. (Or perhaps we should count other files
-		 * towards the database owner?)
-		 */
-		if (!isRelDataFile(path, &rnode))
-			continue;
-
-		/* Also ignore system relations */
-		if (rnode.relNode < FirstNormalObjectId)
-			continue;
-
-		if (stat(path, &statbuf) != 0)
-		{
-			ereport(DEBUG1,
-					(errcode_for_file_access(),
-					 errmsg("could not stat file \"%s\": %m", path)));
-			continue;
-		}
-
-		UpdateFileSize(&rnode, dirent->d_name, statbuf.st_size);
-	}
-
-	FreeDir(dirdesc);
-}
-
-
-/*
- * Scan file system, to update the model with all files.
+ * This update the quota field and update relation size in the in-memory model.
  */
 void
-refresh_fs_model(void)
+UpdateQuotaRefreshRelationSize(Oid relid, int64 newquota, int64 newtotalsize)
 {
-	DIR		   *dirdesc;
-	struct dirent *dirent;
-	char		path[MAXPGPATH];
-	HASH_SEQ_STATUS iter;
-	FileSizeEntry *fsentry;
-
-	/*
-	 * Bump the generation counter first, so that we can detect removed files.
-	 */
-	generation++;
-
-	/* global/<relid> */
-	/* ignore shared relations */
-
-	/* base/<dbid>/<relid> */
-	dirdesc = AllocateDir("base");
-	while ((dirent = ReadDirExtended(dirdesc, "base", DEBUG1)) != NULL)
-	{
-		Oid			dbid;
-
-		if (strcmp(dirent->d_name, ".") == 0 ||
-			strcmp(dirent->d_name, "..") == 0)
-			continue;
-
-		if (sscanf(dirent->d_name, "%u", &dbid) != 1)
-			continue;
-
-		snprintf(path, MAXPGPATH, "base/%s", dirent->d_name);
-		RebuildRelSizeMapDir(path);
-	}
-	FreeDir(dirdesc);
-
-	/*
-	 * pg_tblspc/<tblspc oid>/<tblspc version>/
-	 *		within a non-default tablespace (the name of the directory
-	 *		depends on version)
-	 */
-	/* TODO */
-
-	/*
-	 * Finally, remove files that no longer exist.
-	 */
-	hash_seq_init(&iter, path_to_fsentry_map);
-
-	while ((fsentry = hash_seq_search(&iter)) != NULL)
-	{
-		if (fsentry->generation != generation)
-		{
-			/*
-			 * We didn't see this file during this scan, so it doesn't
-			 * exist anymore.
-			 */
-			RemoveFileSize(fsentry);
-		}
-	}
-}
-
-/*
- * Update the owner of a relation in the model.
- */
-void
-UpdateRelOwner(RelFileNode *rnode, Oid owner)
-{
-	RelSizeEntry *relentry;
-	RoleSizeEntry *rolentry;
-	RoleSizeEntryKey key;
-	bool		found;
-
-	relentry = (RelSizeEntry *) hash_search(relfilenode_to_relentry_map,
-											(void *) rnode,
-											HASH_FIND, &found);
-	if (!found)
-		return;
-
-	if (relentry->owner == owner)
-		return;
-
-	/* Subtract the old size from the old owner's total. */
-	LWLockAcquire(shared->lock, LW_EXCLUSIVE);
-
-	key.rolid = relentry->owner;
-	key.dbid = MyDatabaseId;
-	rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
-											 (void *) &key,
-											 HASH_FIND, &found);
-	Assert(found == (relentry->owner != InvalidOid));
-	if (found)
-		rolentry->totalsize -= relentry->totalsize;
-	LWLockRelease(shared->lock);
-
-	relentry->owner = owner;
-	if (relentry->owner == InvalidOid)
-		dlist_delete(&relentry->orphan_node);
-
-	if (owner != InvalidOid)
-	{
-		/* Link to new parent, creating it if it doesn't exist yet. */
-		key.rolid = owner;
-		key.dbid = MyDatabaseId;
-
-		LWLockAcquire(shared->lock, LW_EXCLUSIVE);
-
-		rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
-												 (void *) &key,
-												 HASH_ENTER, &found);
-		if (!found)
-		{
-			rolentry->totalsize = 0;
-			rolentry->quota = -1;	/* -1 means no quota */
-		}
-		rolentry->totalsize += relentry->totalsize;
-	}
-	else
-		dlist_push_head(&orphanRels, &relentry->orphan_node);
-
-	LWLockRelease(shared->lock);
-}
-
-/*
- * Update the quota for a role.
- *
- * This update the quota field in the in-memory model. This is used when the
- * quotas are loaded from the cofiguration table.
- */
-void
-UpdateQuota(Oid owner, int64 newquota)
-{
-	RoleSizeEntry *rolentry;
-	RoleSizeEntryKey key;
+	RelationSizeEntry *relentry;
+	RelationSizeEntryKey key;
 	bool		found;
 
 	LWLockAcquire(shared->lock, LW_EXCLUSIVE);
 
-	key.rolid = owner;
+	key.relid = relid;
 	key.dbid = MyDatabaseId;
-	rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
+	relentry = (RelationSizeEntry *) hash_search(relation_totals_map,
 											 (void *) &key,
 											 HASH_ENTER, &found);
-	if (!found)
-		rolentry->totalsize = 0;
-
-	rolentry->quota = newquota;
+	relentry->quota = newquota;
+	relentry->totalsize = newtotalsize;
 
 	LWLockRelease(shared->lock);
-}
-
-/*
- * Scan the list of relations that without owner information, and get their
- * owners.
- */
-void
-UpdateOrphans(void)
-{
-	dlist_mutable_iter iter;
-
-	dlist_foreach_modify(iter, &orphanRels)
-	{
-		RelSizeEntry *relentry = (RelSizeEntry *)
-			dlist_container(RelSizeEntry, orphan_node, iter.cur);
-		Oid			owner;
-
-		owner = get_relfilenode_owner(&relentry->rnode);
-		if (owner)
-		{
-			UpdateRelOwner(&relentry->rnode, owner);
-
-			/* Note: UpdateRelOwner() unlinks the entry from this list */
-
-			elog(DEBUG1, "updated owner of relation %u/%u/%u to %u",
-				 relentry->rnode.dbNode, relentry->rnode.spcNode, relentry->rnode.relNode, owner);
-		}
-	}
 }
 
 
@@ -710,30 +209,30 @@ UpdateOrphans(void)
  */
 
 /*
- * Returns 'true', if the quota for 'owner' has not been exceeded yet.
+ * Returns 'true', if the quota for 'relation' has not been exceeded yet.
  */
 bool
-CheckQuota(Oid owner)
+CheckQuota(Oid relid)
 {
-	RoleSizeEntry *rolentry;
-	RoleSizeEntryKey key;
+	RelationSizeEntry *relentry;
+	RelationSizeEntryKey key;
 	bool		result;
 
-	if (!role_totals_map)
+	if (!relation_totals_map)
 		return true;
 
 	LWLockAcquire(shared->lock, LW_SHARED);
 
-	key.rolid = owner;
+	key.relid = relid;
 	key.dbid = MyDatabaseId;
-	rolentry = (RoleSizeEntry *) hash_search(role_totals_map,
+	relentry = (RelationSizeEntry *) hash_search(relation_totals_map,
 											 (void *) &key,
 											 HASH_FIND, NULL);
-	if (rolentry &&
-		rolentry->quota >= 0 &&
-		rolentry->totalsize > rolentry->quota)
+	if (relentry &&
+		relentry->quota >= 0 &&
+		relentry->totalsize > relentry->quota)
 	{
-		/* User has a quota, and it's been exceeded. */
+		/* Relation has a quota, and it's been exceeded. */
 		result = false;
 	}
 	else
@@ -759,7 +258,7 @@ get_quota_status(PG_FUNCTION_ARGS)
 	MemoryContext per_query_ctx;
 	MemoryContext oldcontext;
 	HASH_SEQ_STATUS iter;
-	RoleSizeEntry *rolentry;
+	RelationSizeEntry *relentry;
 
 	/* check to see if caller supports us returning a tuplestore */
 	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
@@ -786,28 +285,28 @@ get_quota_status(PG_FUNCTION_ARGS)
 
 	MemoryContextSwitchTo(oldcontext);
 
-	if (role_totals_map)
+	if (relation_totals_map)
 	{
 		LWLockAcquire(shared->lock, LW_SHARED);
 
-		hash_seq_init(&iter, role_totals_map);
-		while ((rolentry = hash_seq_search(&iter)) != NULL)
+		hash_seq_init(&iter, relation_totals_map);
+		while ((relentry = hash_seq_search(&iter)) != NULL)
 		{
 			/* for each row */
 			Datum		values[GET_QUOTA_STATUS_COLS];
 			bool		nulls[GET_QUOTA_STATUS_COLS];
 
 			/* Ignore entries for other databases. */
-			if (rolentry->key.dbid != MyDatabaseId)
+			if (relentry->key.dbid != MyDatabaseId)
 				continue;
 
-			values[0] = rolentry->key.rolid;
+			values[0] = relentry->key.relid;
 			nulls[0] = false;
-			values[1] = rolentry->totalsize;
+			values[1] = relentry->totalsize;
 			nulls[1] = false;
-			if (rolentry->quota != -1)
+			if (relentry->quota != -1)
 			{
-				values[2] = rolentry->quota;
+				values[2] = relentry->quota;
 				nulls[2] = false;
 			}
 			else

--- a/pg_quota--1.0.sql
+++ b/pg_quota--1.0.sql
@@ -7,17 +7,17 @@ CREATE SCHEMA quota;
 
 set search_path='quota';
 
-CREATE FUNCTION get_quota_status(rolid OUT oid, space_used OUT int8, quota OUT int8)
+CREATE FUNCTION get_quota_status(relid OUT oid, space_used OUT int8, quota OUT int8)
 RETURNS SETOF record STRICT
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
 CREATE VIEW quota.status AS
-SELECT rolid::regrole AS rolname, space_used, quota
+SELECT relid::regclass AS tablename, space_used, quota
 FROM get_quota_status();
 
 -- Configuration table
-create table quota.config (roleid oid PRIMARY key, quota int8);
+create table quota.config (relationid oid PRIMARY key, quota int8);
 
 SELECT pg_catalog.pg_extension_config_dump('quota.config', '');
 

--- a/pg_quota.h
+++ b/pg_quota.h
@@ -7,19 +7,14 @@
 
 #include "storage/relfilenode.h"
 
-/* prototypes for pg_quota.c */
-extern Oid get_relfilenode_owner(RelFileNode *rnode);
 
 /* prototypes for fs_model.c */
 extern void init_fs_model(void);
 extern void init_fs_model_shmem(void);
-extern void refresh_fs_model(void);
 
-extern void UpdateRelOwner(RelFileNode *rnode, Oid owner);
-extern void UpdateOrphans(void);
 
-extern bool CheckQuota(Oid owner);
-extern void UpdateQuota(Oid owner, int64 newquota);
+extern bool CheckQuota(Oid relationid);
+extern void UpdateQuotaRefreshRelationSize(Oid relationid, int64 newquota, int64 newtotalsize);
 
 /* prototypes for enforcement.c */
 extern void init_quota_enforcement(void);

--- a/sql/test_quotas.sql
+++ b/sql/test_quotas.sql
@@ -1,38 +1,23 @@
 
 --
-CREATE USER quotatest_user NOLOGIN;
-
 CREATE TABLE qt (t text);
-ALTER TABLE qt OWNER TO quotatest_user;
 
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
-
--- Wait a little, to make sure the background worker has picked up the new size.
-select pg_sleep(5);
 
 -- Display the table size.
 select pg_size_pretty(pg_total_relation_size('qt'));
 
--- The "disk space used" as shown in quota_status should match
-SELECT rolname,
-       pg_size_pretty(space_used) as used,
-       pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
 
-
-
--- Set a quota for the user.
-INSERT INTO quota.config VALUES ('quotatest_user'::regrole, pg_size_bytes('20 MB'));
+-- Set a quota for the relation.
+INSERT INTO quota.config VALUES ('qt'::regclass, pg_size_bytes('20 MB'));
 
 -- Wait a little, to give the worker a chance to pick up the new quota.
 select pg_sleep(5);
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
+FROM quota.status;
 
 -- Now insert enough data that the quota is exceeded.
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
@@ -40,11 +25,10 @@ INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
 -- and again wait a little, so that the worker picks up the new file size
 select pg_sleep(5);
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
+FROM quota.status;
 
 -- Try to insert again. This should fail, because the quota is exceeded.
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);
@@ -56,10 +40,9 @@ TRUNCATE qt;
 -- and again wait a little, so that the worker picks up the new file size
 select pg_sleep(5);
 
-SELECT rolname,
+SELECT tablename,
        pg_size_pretty(space_used) as used,
        pg_size_pretty(quota) as quota
-FROM quota.status
-WHERE rolname::text like 'quotatest%';
+FROM quota.status;
 
 INSERT INTO qt SELECT repeat('x', 100) FROM generate_series(1, 100000);


### PR DESCRIPTION
Main purpose is to limit a table usage of disk space. and use pg_total_relation_size function to calcuate a table size.

load quota and refresh fs in one function load_quotas_refresh_fs_model. 
Main logic is following
SPI_execute("select relationid, pg_total_relation_size(relationid) int8, quota int8 from quota.config", true, 0);

Have a question I would like to consult you, on applying disk quota on greenplum,  you have said in README:

> Quotas are only checked at the beginning of INSERT and COPY statements.
  As long as the user has not exceeded the quota at the beginning of the
  statement, the INSERT or COPY is allowed to go through, even if it
  causes the quota to be exceeded.

how can greenplum overcome the weakness: allow COPY to cancel on the progress once disk usage is higher than quota not after the query has done,  would like to hear your ideas. 